### PR TITLE
Added card eating rule

### DIFF
--- a/akaCheesedog.md
+++ b/akaCheesedog.md
@@ -41,6 +41,7 @@
 > - RULE 1d: ACES are HIGH.
 > - RULE 1e: If you have multiple of the same card, you may play any number of them at the same time, including all of them at once.
 > - RULE 1f: Cards in your hand must always be played first at any stage of the game.
+> - RULE 1g: If you eat a card, it does not have to be played. This applies to both cards in your hand and FACE-DOWN cards. You must place the intact card in your mouth, chew, and swallow without washing the card down with a beverage.
 
 ### Section 2 - Clearing the Pile
 


### PR DESCRIPTION
Added draft of the card eating rule. Possible clarifications needed - Are you allowed to skip through stages of the game by eating cards at any time? Ex situation: You have one card in your hand remaining, and you have already picked up your FACE-UP cards. You eat your one remaining card and then eat your 4 FACE-DOWN cards in one fell swoop -> win? At face value, this is what 'if you eat a card, it doesn't have to be played' would seem to imply.

Or can you only eat a card to save yourself on your turn before you would play a card(s), in lieu of playing that card(s)? Ex situation: Your hand contains two 6's and one Jack, a Queen has been played, and you have all 4 FACE-UP cards left. You consume the two 6's and the Jack, and play passes to the next player without anyone picking up the stack. You pick up your FACE-UP cards and continue play from there.